### PR TITLE
added failing test for jvm/js diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+resources
+node_modules

--- a/test/cljc/java_time/local_date_time_test.cljc
+++ b/test/cljc/java_time/local_date_time_test.cljc
@@ -1,0 +1,10 @@
+(ns cljc.java-time.local-date-time-test
+  (:require
+    [cljc.java-time.local-date-time :as ldt]
+    [cljc.java-time.month :refer [january]]
+    [clojure.test :refer [deftest is]]))
+
+;; won't pass on JVM. java resolution needs type hints to resolve overloading
+;; I suspect others have this problem.
+(deftest of-works-in-js-and-jvm
+  (is (= (ldt/of 2011 january 3 11 59) (ldt/of 2011 january 3 11 59))))


### PR DESCRIPTION
The JVM uses primitives, often int. Clojure literal integers are Long. This causes overload resolution to fail.

The test in the PR will pass fine in cljs, but fails in clj.

I didn't really look at how you're generating your wrappers, but perhaps this is an easy fix for you.