### PR TITLE
Bump cljs.java-time dependency and add new classes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths   ["src"]
- :deps    {cljs.java-time {:mvn/version "0.1.13"}}
+ :deps    {cljs.java-time {:mvn/version "0.1.15"}}
  :aliases {:dev       {:extra-paths ["dev" "test"]
                        :extra-deps  {medley                      {:mvn/version "0.8.4"}
                                      camel-snake-kebab           {:mvn/version "0.4.0"}

--- a/dev/gen.clj
+++ b/dev/gen.clj
@@ -1,7 +1,6 @@
  (ns gen
    (:require [clojure.reflect :as rf]
              [clojure.set :as set]
-             [medley.core :as m]
              [defwrapper :as df]
              [clojure.string :as string]
              [camel-snake-kebab.core :as csk]
@@ -23,15 +22,28 @@
                        Duration
                        Year
                        YearMonth
-                       Clock ZoneOffset]
+                       Clock
+                       ZoneOffset]
             [java.time.format DateTimeFormatter
-                              ResolverStyle]
+                              DateTimeFormatterBuilder
+                              ResolverStyle
+                              DecimalStyle
+                              SignStyle
+                              TextStyle]
             [java.time.temporal TemporalAdjusters
                                 Temporal
                                 TemporalAmount
                                 ChronoUnit
-                                ChronoField]))
- 
+                                ChronoField
+                                IsoFields
+                                TemporalAccessor
+                                TemporalAdjuster
+                                TemporalQuery
+                                TemporalQueries
+                                TemporalUnit
+                                ValueRange
+                                TemporalField]))
+
  (defn header [class-name ns-name sub-p]
    (list 'ns (symbol (str "cljc.java-time." (when sub-p (str sub-p ".")) ns-name))
      (list :require
@@ -42,7 +54,7 @@
      (symbol "#?") (list
                             :clj
                             (list :import [(symbol (str "java.time" (when sub-p (str "." sub-p)))) class-name]))))
- 
+
  (defn type-hint [x]
    (let [x (string/replace (str x) "<>" "")]
      (when (or (clojure.string/includes? x ".")
@@ -68,7 +80,7 @@
               f)]
       (pr f))
     (println)))
- 
+
  (defn generate-library-code! []
    ;todo - chrono and zone packages. needs cljs.java-time also
    (binding [*print-meta* true]
@@ -107,18 +119,19 @@
          (binding [*out* w]
            (gen-for-class c "temporal"))))
      (doseq [c [DateTimeFormatter
+                DateTimeFormatterBuilder
                 ResolverStyle]]
        (let [f (str "./src/cljc/java_time/format/" (csk/->snake_case (.getSimpleName c)) ".cljc")
              _ (io/make-parents f)
              w (io/writer f)]
          (binding [*out* w]
            (gen-for-class c "format"))))))
- 
- (comment 
-   
+
+ (comment
+
    (generate-library-code!)
    (require '[clojure.tools.namespace.repl :as rep])
    (rep/refresh-all)
-   
-   
+
+
    )

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>cljc.java-time</groupId>
   <artifactId>cljc.java-time</artifactId>
-  <version>0.1.7</version>
+  <version>0.1.8</version>
   <name>cljc.java-time</name>
     <description>A Clojure(Script) library which provides the java.time api through kebab-case-named function vars.</description>
     <url>https://github.com/henryw374/cljc.java-time</url>
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>cljs.java-time</groupId>
       <artifactId>cljs.java-time</artifactId>
-      <version>0.1.13</version>
+      <version>0.1.15</version>
     </dependency>
   </dependencies>
     <build>


### PR DESCRIPTION
Adding the new classes that were added to cljs-java-time.

This should need another commit to add the auto-generated code for the new 
classes, feel free to add it. Thanks